### PR TITLE
Better error handling when adding dependency

### DIFF
--- a/com.dubture.composer.core/src/com/dubture/composer/core/job/ComposerJob.java
+++ b/com.dubture.composer.core/src/com/dubture/composer/core/job/ComposerJob.java
@@ -2,6 +2,7 @@ package com.dubture.composer.core.job;
 
 import java.io.IOException;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -25,13 +26,13 @@ abstract public class ComposerJob extends Job
     }
 
     protected void execute(String argument, IProgressMonitor monitor) throws IOException,
-            InterruptedException
+            InterruptedException, CoreException
     {
         doExecute(new String[]{argument}, monitor);
     }
 
     protected void execute(String argument, String[] composerArgs, IProgressMonitor monitor)
-            throws IOException, InterruptedException
+            throws IOException, InterruptedException, CoreException
     {
         String[] args = new String[composerArgs.length + 1];
         args[0] = argument;
@@ -39,7 +40,7 @@ abstract public class ComposerJob extends Job
         doExecute(args, monitor);
     }
     
-    private void doExecute(String[] arguments, IProgressMonitor monitor) throws IOException, InterruptedException 
+    private void doExecute(String[] arguments, IProgressMonitor monitor) throws IOException, InterruptedException, CoreException 
     {
         new DefaultExecutableLauncher().launch(composer, arguments, new ConsoleResponseHandler(monitor));
     }

--- a/com.dubture.composer.core/src/com/dubture/composer/core/launch/DefaultExecutableLauncher.java
+++ b/com.dubture.composer.core/src/com/dubture/composer/core/launch/DefaultExecutableLauncher.java
@@ -11,14 +11,19 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
+import com.dubture.composer.core.ComposerPlugin;
 import com.dubture.composer.core.log.Logger;
 import com.dubture.composer.core.ui.ExecutableNotFoundException;
 import com.dubture.composer.core.ui.LaunchUtil;
@@ -27,7 +32,7 @@ import com.dubture.composer.core.ui.LaunchUtil;
 public class DefaultExecutableLauncher implements IPHPLauncher {
 
 	@Override
-	public void launch(String scriptPath, String[] arguments, ILaunchResponseHandler handler) throws IOException, InterruptedException {
+	public void launch(String scriptPath, String[] arguments, ILaunchResponseHandler handler) throws IOException, InterruptedException, CoreException {
 
 		doLaunch(scriptPath, arguments, handler, false);
 		
@@ -35,13 +40,13 @@ public class DefaultExecutableLauncher implements IPHPLauncher {
 
 	@Override
 	public void launchAsync(String scriptPath, String[] arguments, ILaunchResponseHandler handler)
-			throws IOException, InterruptedException {
+			throws IOException, InterruptedException, CoreException {
 
 		doLaunch(scriptPath, arguments, handler, true);
 		
 	}
 	
-	protected void doLaunch(String scriptPath, String[] arguments, ILaunchResponseHandler handler, boolean async) throws IOException, InterruptedException {
+	protected void doLaunch(String scriptPath, String[] arguments, ILaunchResponseHandler handler, boolean async) throws IOException, InterruptedException, CoreException {
 		
 		String phpExe = null;
 		
@@ -108,7 +113,7 @@ public class DefaultExecutableLauncher implements IPHPLauncher {
         BufferedReader errOutput=new BufferedReader(new InputStreamReader(p
                 .getErrorStream()));
         String errResult="";
-        String errTemp=output.readLine();
+        String errTemp=errOutput.readLine();
         while (errTemp != null) {
             if (errTemp.trim().length() > 0) {
                 errResult=errResult + "\n" + errTemp;
@@ -116,8 +121,12 @@ public class DefaultExecutableLauncher implements IPHPLauncher {
             errTemp=errOutput.readLine();
         }
         
-		if (handler != null) {
+        if (handler != null) {
 			handler.handle(result.trim());
+		}
+		
+		if (p.exitValue() != 0) {
+		    throw new CoreException(new Status(IStatus.ERROR, ComposerPlugin.ID, result+errResult));
 		}
 	}
 }

--- a/com.dubture.composer.core/src/com/dubture/composer/core/launch/IPHPLauncher.java
+++ b/com.dubture.composer.core/src/com/dubture/composer/core/launch/IPHPLauncher.java
@@ -9,10 +9,12 @@ package com.dubture.composer.core.launch;
 
 import java.io.IOException;
 
+import org.eclipse.core.runtime.CoreException;
+
 
 public interface IPHPLauncher {
 
-	void launch(String scriptPath, String[] arguments, ILaunchResponseHandler handler) throws IOException, InterruptedException;
+	void launch(String scriptPath, String[] arguments, ILaunchResponseHandler handler) throws IOException, InterruptedException, CoreException;
 	
-	void launchAsync(String scriptPath, String[] arguments, ILaunchResponseHandler handler) throws IOException, InterruptedException;
+	void launchAsync(String scriptPath, String[] arguments, ILaunchResponseHandler handler) throws IOException, InterruptedException, CoreException;
 }

--- a/com.dubture.composer.core/src/com/dubture/composer/core/ui/wizard/require/RequirePageTwo.java
+++ b/com.dubture.composer.core/src/com/dubture/composer/core/ui/wizard/require/RequirePageTwo.java
@@ -45,6 +45,7 @@ public class RequirePageTwo extends AbstractItemInstallerPage implements IPageCh
         setDescription("Choose the versions to install for the selected packages");
         this.firstPage = pageOne;
         setPackages(new HashMap<EclipsePHPPackage, String>());
+        setPageComplete(false);
     }
 
     @Override
@@ -121,6 +122,7 @@ public class RequirePageTwo extends AbstractItemInstallerPage implements IPageCh
     {
         if (event.getSelectedPage() == this) {
             loadPackages();
+            setPageComplete(items.size() > 0);
         }
     }
 


### PR DESCRIPTION
- make sure that composer.json gets refreshed after adding dependency
- bug that errorOuptut was always empty and checking composer return
  code
- composer.json was not being refreshed after "add dependency" in project with "vendor" dir, even though composer was inserting new dependency into it
