### PR TITLE
Sort build path candidates to make nesting detection work.

### DIFF
--- a/com.dubture.composer.core/src/com/dubture/composer/core/buildpath/BuildPathManager.java
+++ b/com.dubture.composer.core/src/com/dubture/composer/core/buildpath/BuildPathManager.java
@@ -129,11 +129,11 @@ public class BuildPathManager {
 			List<IPath> exclusions = new ArrayList<IPath>(); 
 			exclusions.addAll(Arrays.asList(parent.getExclusionPatterns()));
 			
-			IPath diff = path
-					.removeFirstSegments(path.matchingFirstSegments(parent.getPath()))
-					.uptoSegment(1)
-					.removeTrailingSeparator()
-					.addTrailingSeparator();
+			IPath diff = path.removeFirstSegments(path.matchingFirstSegments(parent.getPath()));
+			if (parent.getPath().equals(composerPath)) {
+				diff = path.uptoSegment(1);
+			}
+			diff = diff.removeTrailingSeparator().addTrailingSeparator();
 			if (!exclusions.contains(diff)) {
 				exclusions.add(diff);
 			}


### PR DESCRIPTION
While trying to setup a Symfony project i constantly "lost" the whole buildpath after adding some require-dev entries for docs generation. 
After lots of trial and error and finally some debugging i realized DLTK BuildpathUtils threw an exception (i did not find in the log) about nested paths when adding new buildpath items.
This was reproducable by adding "require-dev":{"pear/log":"dev-master"} to composer.json.
My fix is to sort paths list in BuildPathManager.update method. This works for me, but i don't know how exactly handling of inclusion / exclusion patterns work and if this could be affected by the change...
