### PR TITLE
Converting Windows paths to Unix paths

### DIFF
--- a/com.dubture.composer.core/src/com/dubture/composer/core/buildpath/BuildPathParser.java
+++ b/com.dubture.composer.core/src/com/dubture/composer/core/buildpath/BuildPathParser.java
@@ -13,31 +13,31 @@ import com.dubture.getcomposer.core.objects.Autoload;
 import com.dubture.getcomposer.core.objects.Namespace;
 
 public class BuildPathParser {
-	
+
 	private IComposerProject project;
 
 	public BuildPathParser(IComposerProject project) {
 		this.project = project;
 	}
-	
+
 	public List<String> getPaths() {
 		ComposerPackages packages = project.getInstalledPackages();
 		if (packages == null) {
 			return null;
 		}
-		
+
 		ComposerPackage composer = project.getComposerPackage();
 		String vendor = project.getVendorDir();
-		
+
 		// empty list for found package paths
 		List<String> paths = new ArrayList<String>();
-		
+
 		// add source paths from this package
 		parsePackage(composer, paths);
-		
+
 		// add composer vendor dir
 		paths.add(vendor + "/composer");
-		
+
 		// all installed packages
 		for (ComposerPackage p : packages) {
 			parsePackage(p, paths, vendor + "/" + p.getName());
@@ -45,45 +45,45 @@ public class BuildPathParser {
 
 		return paths;
 	}
-	
+
 	private void parsePackage(ComposerPackage pkg, List<String> paths) {
 		parsePackage(pkg, paths, "");
 	}
-	
+
 	private void parsePackage(ComposerPackage pkg, List<String> paths, String prefix) {
 		if (prefix != null && !prefix.equals("") && !prefix.endsWith("/")) {
 			prefix += "/";
 		}
 
 		Autoload a = pkg.getAutoload();
-		
+
 		// psr-0
 		for (Namespace namespace : a.getPsr0()) {
 			for (Object path : namespace.getPaths()) {
 				addPath(prefix + path, paths);
 			}
 		}
-		
+
 		// psr-4
 		for (Namespace namespace : a.getPsr4()) {
 			for (Object path : namespace.getPaths()) {
 				addPath(prefix + path, paths);
 			}
 		}
-		
+
 		// classmap
 		for (Object path : a.getClassMap()) {
 			String cleanedPath = getDirectory(prefix + (String) path);
 			addPath(cleanedPath, paths);
 		}
-		
+
 		// files
 		for (Object path : a.getFiles()) {
 			String cleanedPath = getDirectory(prefix + (String) path);
 			addPath(cleanedPath, paths);
 		}
 	}
-	
+
 	private String getDirectory(String path) {
 		String cleanedPath = null;
 		IPath root = project.getProject().getLocation();
@@ -97,36 +97,39 @@ public class BuildPathParser {
 		}
 		return cleanedPath;
 	}
-	
+
 	private void addPath(String path, List<String> paths) {
 		if (path != null && !path.trim().isEmpty()) {
+			// switch from win to unix
+			path = path.replaceAll("\\\\", "/");
+
 			// path cleanup
 			if (path.startsWith("/")) {
 				path = path.substring(1);
 			}
-			
+
 			if (path.endsWith("/.")) {
 				path = path.substring(0, path.length() - 2);
 			}
-			
+
 			if (path.endsWith("/")) {
 				path = path.substring(0, path.length() - 1);
 			}
-			
+
 			if (path.equals(".")) {
 				path = "";
 			}
-			
+
 //			if (!path.isEmpty()) {
 //				path = project.getProject().getFullPath().toString() + "/" + path;
 //			} else {
 //				path = project.getProject().getFullPath().toString();
 //			}
-			
+
 			if (path.startsWith("/")) {
 				path = path.substring(1);
 			}
-			
+
 			if (!paths.contains(path)) {
 				paths.add(path);
 			}


### PR DESCRIPTION
Windows file system path is converted to Unix path (changing slashes). This is required so that nested path detection works properly. Fixes #117.
