### PR TITLE
Composer command should specify php.ini location

### DIFF
--- a/com.dubture.composer.core/src/com/dubture/composer/core/launch/environment/SysPhpPrjPhar.java
+++ b/com.dubture.composer.core/src/com/dubture/composer/core/launch/environment/SysPhpPrjPhar.java
@@ -1,8 +1,11 @@
 package com.dubture.composer.core.launch.environment;
 
+import java.io.File;
+
 import org.apache.commons.exec.CommandLine;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.php.internal.debug.core.phpIni.PHPINIUtil;
 import org.pdtextensions.core.launch.environment.PrjPharEnvironment;
 
 public class SysPhpPrjPhar extends PrjPharEnvironment {
@@ -19,10 +22,19 @@ public class SysPhpPrjPhar extends PrjPharEnvironment {
 
 	public CommandLine getCommand() {
 		CommandLine cmd = new CommandLine(php.trim());
-		cmd.addArgument(phar.trim());
 		
+		// specify php.ini location
+		File iniFile = PHPINIUtil.findPHPIni(php);
+		if (iniFile != null) {
+			cmd.addArgument("-c");
+			cmd.addArgument(iniFile.getAbsolutePath());
+		}
+		
+		// specify composer.phar location
+		cmd.addArgument(phar.trim());
 		return cmd;
 	}
+	
 	@Override
 	protected IResource getScript(IProject project) {
 		return project.findMember("composer.phar");


### PR DESCRIPTION
Currently the Composer plugin does not include "-c <php.ini-location>"
parameter in the command that execute the composer.phar in an external
process.

This may cause troubles if multiple PHP installations are available on
the system. There may be installations (like Zend Server) which register
the php.ini file in the Windows Registry. This takes precedence over
php.ini in the same folder as the php.exe. Hence, if Composer is
configured to run with another PHP executable which has a php.ini in the
php.exe folder, it will actually be executed with the php.ini of Zend
Server. This causes lots of problems, like Composer miserably fails.

The solution is to include "-c <php.ini-location>" parameter in the
command. Which this patch actually does using the handy
PHPINIUtil.findPHPIni() method from PDT to locate the php.ini file.